### PR TITLE
Add putObject parameters from s3params file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-s3",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-s3",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "SDM extension pack for publishing artifacts to AWS S3",
   "author": {
     "name": "Atomist",


### PR DESCRIPTION
Read additional S3 putObject parameter object properties from hidden
.s3params file for each file put, if it exists.

Add test for pushToS3.

Move to .promise() function provided by aws-sdk rather than
util.promisify().

Rename some variables to be more clear.

Increment minor version.

Closes #11